### PR TITLE
Update schema documentation links to point to correct page.

### DIFF
--- a/website/apps/ts_om/templates/ts_om/summary.html
+++ b/website/apps/ts_om/templates/ts_om/summary.html
@@ -202,7 +202,7 @@
                     <div class="row">
                         <div class="col-md-12">
                             <span class="pull-right" id="further-info">
-                                Schema v32: <a target="_blank" href="https://github.com/SwissTPH/openmalaria/wiki/GeneratedSchema32Doc">Doc</a>
+                                Schema v32: <a target="_blank" href="https://github.com/SwissTPH/openmalaria/wiki/schema-32">Doc</a>
                                 | <a download="scenario_32.xsd" href="{{ STATIC_URL }}ts_om/files/scenario_32.xsd">Download</a>
                             </span>
                         </div>

--- a/website/apps/ts_om_edit/templates/ts_om_edit/base.html
+++ b/website/apps/ts_om_edit/templates/ts_om_edit/base.html
@@ -85,7 +85,7 @@
                     <div class="row">
                         <div class="col-md-9">
                             <span class="help-block" id="further-info">
-                                Schema v32: <a target="_blank" href="https://github.com/SwissTPH/openmalaria/wiki/GeneratedSchema32Doc">Doc</a>
+                                Schema v32: <a target="_blank" href="https://github.com/SwissTPH/openmalaria/wiki/schema-32">Doc</a>
                                 | <a download="scenario_32.xsd" href="{{ STATIC_URL }}ts_om/files/scenario_32.xsd">Download</a>
                             </span>
                         </div>


### PR DESCRIPTION
Reason: The links were updated upstream to a new format.