### PR TITLE
Fix broken data services tests.

### DIFF
--- a/data_services/tests/models/test_simulation.py
+++ b/data_services/tests/models/test_simulation.py
@@ -16,7 +16,7 @@ class SimulationModelTest(TestCase):
             group=self.sim_group,
             model="123",
             version="v30",
-            status="COMPLETE"
+            status="DONE"
         )
 
     def test_duration_as_timedelta_none(self):
@@ -33,7 +33,7 @@ class SimulationModelTest(TestCase):
         self.assertEqual(self.simulation.ended_when, datetime.datetime(1990, 12, 12, second=30))
 
     def test_str(self):
-        self.assertEqual(str(self.simulation), "1 (123 vv30) - COMPLETE")
+        self.assertEqual(str(self.simulation), "1 (123 vv30) - DONE")
 
     def test_copy(self):
         new_simulation = self.simulation.copy()

--- a/data_services/tests/models/test_simulation.py
+++ b/data_services/tests/models/test_simulation.py
@@ -33,7 +33,8 @@ class SimulationModelTest(TestCase):
         self.assertEqual(self.simulation.ended_when, datetime.datetime(1990, 12, 12, second=30))
 
     def test_str(self):
-        self.assertEqual(str(self.simulation), "1 (123 vv30) - DONE")
+        simulation_as_string = "{} (123 vv30) - DONE".format(self.simulation.id)
+        self.assertEqual(str(self.simulation), simulation_as_string)
 
     def test_copy(self):
         new_simulation = self.simulation.copy()


### PR DESCRIPTION
This fixes some broken tests in the data services app:

- Simulation's `status` field has a `max_length` == vecnet.simulation package's 
sim_status `MAX_LENGTH`, which is currently set to 7.
- The other fix involves using the test simulation's id in place of `1` when 
testing the output of str(simulation).